### PR TITLE
Minor UI tweaks (margin, padding, card shapes)

### DIFF
--- a/app/src/main/java/com/bnyro/clock/ui/components/AlarmRow.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/components/AlarmRow.kt
@@ -51,7 +51,8 @@ fun AlarmRow(alarm: Alarm, alarmModel: AlarmModel) {
     }
 
     ElevatedCard(
-        modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp)
+        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+        shape = RoundedCornerShape(20.dp)
     ) {
         var expanded by remember {
             mutableStateOf(false)

--- a/app/src/main/java/com/bnyro/clock/ui/screens/ClockScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/screens/ClockScreen.kt
@@ -40,7 +40,7 @@ fun ClockScreen(clockModel: ClockModel) {
         val scrollState = rememberScrollState()
         Column(
             modifier = Modifier
-                .padding(horizontal = 10.dp)
+                .padding(horizontal = 12.dp, vertical = 6.dp)
                 .verticalScroll(scrollState)
         ) {
             ElevatedCard(
@@ -65,7 +65,7 @@ fun ClockScreen(clockModel: ClockModel) {
                 }
             }
 
-            Spacer(modifier = Modifier.height(10.dp))
+            Spacer(modifier = Modifier.height(6.dp))
 
             val zones = clockModel.selectedTimeZones.distinct()
             val sortedZones = when (clockModel.sortOrder) {
@@ -82,7 +82,7 @@ fun ClockScreen(clockModel: ClockModel) {
                     ElevatedCard(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(vertical = 5.dp),
+                            .padding(vertical = 6.dp),
                         shape = RoundedCornerShape(20.dp)
                     ) {
                         Column(
@@ -162,7 +162,7 @@ fun ClockScreen(clockModel: ClockModel) {
 
                         items(filteredZones) {
                             Row(
-                                modifier = Modifier.fillMaxWidth().padding(vertical = 5.dp),
+                                modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
                                 var checked by remember {

--- a/app/src/main/java/com/bnyro/clock/ui/screens/StopwatchScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/screens/StopwatchScreen.kt
@@ -95,7 +95,7 @@ fun StopwatchScreen(stopwatchModel: StopwatchModel) {
         }
         Row(
             modifier = Modifier
-                .padding(bottom = 24.dp),
+                .padding(bottom = 16.dp),
             horizontalArrangement = Arrangement.Center
         ) {
             AnimatedVisibility(stopwatchModel.scheduledObject.state.value == WatchState.RUNNING) {

--- a/app/src/main/java/com/bnyro/clock/ui/screens/TimerScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/screens/TimerScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Edit
@@ -167,10 +168,8 @@ fun TimerScreen(timerModel: TimerModel) {
                     }
 
                     ElevatedCard(
-                        modifier = Modifier.padding(
-                            horizontal = 8.dp,
-                            vertical = 4.dp
-                        )
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                        shape = RoundedCornerShape(20.dp)
                     ) {
                         Row(
                             modifier = Modifier.padding(


### PR DESCRIPTION
I noticed a few UI things. The alarm and timer cards have a smaller corner radius than the clock card. The clock card sits slightly further up than the others. The space between the default clock card and newly added clocks is bigger than the space between new clocks. Padding is not the same in all tabs. So I did some minor tweaks here and there. Everything looks nice and even now :)

Changes:

- Added corner radius to alarm card
- Added corner radius to timer card
- Added padding to clock card
- Reduced spacer between main clock and time zone cards to the same value as padding
- Set padding to the same values in all tabs