### PR TITLE
Time picker changes (closes #103)

### DIFF
--- a/app/src/main/java/com/bnyro/clock/ui/components/NumberPicker.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/components/NumberPicker.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Divider
 import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -101,7 +102,10 @@ fun NumberPicker(
                 }
             )
     ) {
-        Divider(modifier = Modifier.height(1.dp))
+        Divider(
+            modifier = Modifier.height(4.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant
+        )
 
         Spacer(modifier = Modifier.height(4.dp))
 
@@ -134,7 +138,10 @@ fun NumberPicker(
 
         Spacer(modifier = Modifier.height(4.dp))
 
-        Divider(modifier = Modifier.height(1.dp))
+        Divider(
+            modifier = Modifier.height(4.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant
+        )
     }
 }
 

--- a/app/src/main/java/com/bnyro/clock/ui/screens/TimerScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/screens/TimerScreen.kt
@@ -81,13 +81,14 @@ fun TimerScreen(timerModel: TimerModel) {
             ) {
                 if (useOldPicker) {
                     Row(
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
                         NumberPicker(
                             modifier = Modifier
                                 .weight(1f)
-                                .padding(horizontal = 10.dp),
-                            textStyle = MaterialTheme.typography.headlineMedium,
+                                .padding(start = 24.dp, end = 8.dp),
+                            textStyle = MaterialTheme.typography.displayLarge,
                             value = timerModel.getHours(),
                             onValueChanged = timerModel::addHours,
                             range = 0..24
@@ -95,8 +96,8 @@ fun TimerScreen(timerModel: TimerModel) {
                         NumberPicker(
                             modifier = Modifier
                                 .weight(1f)
-                                .padding(horizontal = 10.dp),
-                            textStyle = MaterialTheme.typography.headlineMedium,
+                                .padding(start = 16.dp, end = 16.dp),
+                            textStyle = MaterialTheme.typography.displayLarge,
                             value = timerModel.getMinutes(),
                             onValueChanged = timerModel::addMinutes,
                             range = 0..60
@@ -104,8 +105,8 @@ fun TimerScreen(timerModel: TimerModel) {
                         NumberPicker(
                             modifier = Modifier
                                 .weight(1f)
-                                .padding(horizontal = 10.dp),
-                            textStyle = MaterialTheme.typography.headlineMedium,
+                                .padding(start = 8.dp, end = 24.dp),
+                            textStyle = MaterialTheme.typography.displayLarge,
                             value = timerModel.getSeconds(),
                             onValueChanged = timerModel::addSeconds,
                             range = 0..60


### PR DESCRIPTION
- Fixed time picker being pinned to the top
- Increased number size (closes #103)
- Small tweaks to the divider color, thickness and padding values to better match the increased number size

 Also there is an unused import directive in TimerScreen.kt. I left this unchanged for now.