### PR TITLE
Small settings menu improvements

### DIFF
--- a/app/src/main/java/com/bnyro/clock/ui/prefs/ButtonGroupPref.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/prefs/ButtonGroupPref.kt
@@ -34,16 +34,15 @@ fun ButtonGroupPref(
 ) {
     Column(
         modifier = Modifier
-            .padding(horizontal = 10.dp)
-            .padding(top = 10.dp)
+            .padding(top = 8.dp)
     ) {
         Text(title)
-        Spacer(modifier = Modifier.height(5.dp))
+        Spacer(modifier = Modifier.height(8.dp))
         Row(
             modifier = Modifier
                 .fillMaxWidth()
         ) {
-            val cornerRadius = 16.dp
+            val cornerRadius = 20.dp
             var selectedItem by remember {
                 mutableStateOf(
                     Preferences.instance.getString(preferenceKey, defaultValue)

--- a/app/src/main/java/com/bnyro/clock/ui/prefs/IconPreference.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/prefs/IconPreference.kt
@@ -28,7 +28,7 @@ fun IconPreference(
             .clickable(interactionSource = interactionSource, indication = null) {
                 onClick.invoke()
             }
-            .padding(start = 10.dp, top = 7.dp),
+            .padding(top = 8.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/app/src/main/java/com/bnyro/clock/ui/prefs/SettingsCategory.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/prefs/SettingsCategory.kt
@@ -8,24 +8,19 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 
 @Composable
 fun SettingsCategory(
     title: String
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(
-                start = 10.dp,
-                top = 5.dp
-            )
+        modifier = Modifier.fillMaxWidth()
+            .padding(top = 16.dp)
     ) {
         Text(
             text = title.uppercase(),
-            fontSize = 10.sp,
-            color = MaterialTheme.colorScheme.secondary
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.primary
         )
     }
 }

--- a/app/src/main/java/com/bnyro/clock/ui/prefs/SwitchPref.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/prefs/SwitchPref.kt
@@ -5,8 +5,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Switch
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -14,11 +13,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import com.bnyro.clock.util.Preferences
 
 @Composable
-fun CheckboxPref(
+fun SwitchPref(
     prefKey: String,
     title: String,
     summary: String? = null,
@@ -35,7 +33,6 @@ fun CheckboxPref(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 10.dp)
             .clickable(
                 interactionSource = interactionSource,
                 indication = null
@@ -50,7 +47,7 @@ fun CheckboxPref(
             title = title,
             summary = summary
         )
-        Checkbox(
+        Switch(
             checked = checked,
             onCheckedChange = {
                 checked = it

--- a/app/src/main/java/com/bnyro/clock/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/screens/SettingsScreen.kt
@@ -1,9 +1,7 @@
 package com.bnyro.clock.ui.screens
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -19,9 +17,9 @@ import com.bnyro.clock.BuildConfig
 import com.bnyro.clock.R
 import com.bnyro.clock.ui.model.SettingsModel
 import com.bnyro.clock.ui.prefs.ButtonGroupPref
-import com.bnyro.clock.ui.prefs.CheckboxPref
 import com.bnyro.clock.ui.prefs.IconPreference
 import com.bnyro.clock.ui.prefs.SettingsCategory
+import com.bnyro.clock.ui.prefs.SwitchPref
 import com.bnyro.clock.util.IntentHelper
 import com.bnyro.clock.util.Preferences
 
@@ -35,10 +33,9 @@ fun SettingsScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 5.dp)
+            .padding(horizontal = 16.dp)
             .verticalScroll(scrollState)
     ) {
-        Spacer(modifier = Modifier.height(10.dp))
         SettingsCategory(stringResource(R.string.appearance))
         ButtonGroupPref(
             preferenceKey = Preferences.themeKey,
@@ -51,12 +48,12 @@ fun SettingsScreen(
         ) {
             settingsModel.themeMode = it
         }
-        CheckboxPref(
+        SwitchPref(
             prefKey = Preferences.showSecondsKey,
             title = stringResource(R.string.show_seconds),
             defaultValue = true
         )
-        CheckboxPref(
+        SwitchPref(
             prefKey = Preferences.timerUsePickerKey,
             title = stringResource(R.string.timer_useTimePicker),
             defaultValue = false

--- a/app/src/main/java/com/bnyro/clock/ui/screens/TimerScreen.kt
+++ b/app/src/main/java/com/bnyro/clock/ui/screens/TimerScreen.kt
@@ -1,6 +1,5 @@
 package com.bnyro.clock.ui.screens
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -96,7 +95,7 @@ fun TimerScreen(timerModel: TimerModel) {
                         NumberPicker(
                             modifier = Modifier
                                 .weight(1f)
-                                .padding(start = 16.dp, end = 16.dp),
+                                .padding(horizontal = 16.dp),
                             textStyle = MaterialTheme.typography.displayLarge,
                             value = timerModel.getMinutes(),
                             onValueChanged = timerModel::addMinutes,


### PR DESCRIPTION
- use switches instead of checkboxes
- use primary color to highlight settings categories
- make theme picker pill shaped
- reduce repetitive code by removing horizontal padding from all settings items (unnecessary because already handled by colum)
- change 1 line requested in last PR

Before:
![Screenshot_20230720-151836](https://github.com/Bnyro/ClockYou/assets/82398591/00ae3bc5-0ca7-4adf-810c-2db866783d88)

After:
![Screenshot_20230720-151832](https://github.com/Bnyro/ClockYou/assets/82398591/96a20672-bac4-4257-a094-6587e5b3034d)
